### PR TITLE
同步数据

### DIFF
--- a/examples/counter/counter_service_def.h
+++ b/examples/counter/counter_service_def.h
@@ -50,7 +50,7 @@ public:
 };
 
 struct CounterService {
-    int Incr(rpc_conn, int delta) {}
+    void Incr(rpc_conn, int delta) {}
 };
 
 }  // namespace counter

--- a/src/node/node.h
+++ b/src/node/node.h
@@ -29,17 +29,19 @@ public:
 
     void RequestPreVote();
 
-    void OnRequestPreVote(rpc::RpcConn conn, const std::string &endpoint_str) override;
+    void OnRequestPreVote(rpc::RpcConn conn, const std::string &endpoint_str,
+                          int32_t term_id) override;
 
     void OnPreVote(const boost::system::error_code &ec, string_view data);
 
     void RequestVote();
 
-    void OnRequestVote(rpc::RpcConn conn, const std::string &endpoint_str) override;
+    void OnRequestVote(rpc::RpcConn conn, const std::string &endpoint_str,
+                       int32_t term_id) override;
 
     void OnVote(const boost::system::error_code &ec, string_view data);
 
-    void OnRequestHeartbeat(rpc::RpcConn conn) override;
+    void OnRequestHeartbeat(rpc::RpcConn conn, int32_t term_id) override;
 
     void RequestHeartbeat();
 
@@ -47,6 +49,8 @@ private:
     void ConnectToOtherNodes();
 
     void InitRpcHandlers();
+
+    void StepBack(int32_t term_id);
 
 private:
     TimerManager timer_manager_;

--- a/src/rpc/services.h
+++ b/src/rpc/services.h
@@ -12,11 +12,13 @@ using RpcConn = rest_rpc::rpc_service::rpc_conn;
  */
 class NodeService {
 protected:
-    virtual void OnRequestPreVote(RpcConn conn, const std::string &endpoint_str) = 0;
+    virtual void OnRequestPreVote(RpcConn conn, const std::string &endpoint_str,
+                                  int32_t termid) = 0;
 
-    virtual void OnRequestVote(RpcConn conn, const std::string &endpoint_str) = 0;
+    virtual void OnRequestVote(RpcConn conn, const std::string &endpoint_str,
+                               int32_t termid) = 0;
 
-    virtual void OnRequestHeartbeat(RpcConn conn) = 0;
+    virtual void OnRequestHeartbeat(RpcConn conn, int32_t termid) = 0;
 };
 
 }  // namespace rpc


### PR DESCRIPTION
* 。

* add CI to support macos&ubuntu

* Add RaftNode (#39)

* Update Rest_rpcExternalProject.cmake

* add RaftNode
TODO:
use gflags to parse argv;
optimize raft node ut;

* Refine logger (#38)

* add LOG_DEBUG

* asio rest_rpc cmake

* Delete nanolog.hpp

* rest_rpc asio cmake

* addlogdebug

* addlogdebug

* addlogdebug

* addlogdebug

* release mode donn't output LogLevel::DEBUG

* add check_islogged function

* refine function name

Co-authored-by: 20083017 <651756340@qq.com>

* Refine structure (#41)

* Refine node.(#42)

* Add a simple tool `flags` for parse command line. (#43)

* Add flags

* flag

* Add more test for flags

* Hot fix CI.(#45)

* Refine run_all_tests for ci (#48)

* Add gflags. (#49)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>

* Enable code style check in CI. (#76)

* add clang-format check

* add set -x to shell scripts

* modify git-clang-format

* modify git-clang-format sh

* dev test

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* git-clang-format test

Co-authored-by: wangxing4 <wangxing4@100tal.com>

* git clang format (#78)

* git clang format

* delete useless code

* more jobs

* Run cpp lint on ubuntu only. (#80)

* Refine Counter example (#79)

* WIP

* WIP

* Fix

* FIx

* Fix compling

* Lint

* Fix lint

* Fix lint

* Minor refines (#81)

* FIX

* Fix

* Fix

* Fix lint

* Fix on windows

* Refine node (#82)

* Fix

* fix

* Fix

* Fix

* Fix lint

* Remove unnecessary test.

* Fix

* Fix

* Add log manager interface (#84)

* log

* Fix lint

* Implement Config class (#85)

* Add a random timer encapsulation for boost::timer. (#86)

* Add a timer.

* Add timer test.

* Fix lint

* Fix

* Fix lint

* FIx

* Fix test in macos

* Fix

* Fix config (#87)

* Add TimerManager (#88)

* Add cc library (#89)

* DONE

* Fix

* Fix lint

* Add cmake function to simplify test (#97)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

* add cmake function for test

Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>

* Add rpc server and rpc clients for node. (#98)

* WIP

* Fix

* Fix

* FIx

* Add remote call for node.  (#102)

* Clean code (#103)

* clean code.

* Fix

* Reset timer (#104)

* WIP

* Fix

* Fix

* Fix

* Fix lint

* Add ContinuousTimer. (#105)

* add ContinuousTimer

* Update timer.h of ContinuousTimer

* Update test_time.cc of ContinuousTimer

* Update timer.h of ContinuousTimer

Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>

* Add heartbeat rpc. (#106)

* Fix

* Fix

* Fix lint

* Add a mock logging. (#107)

* Fix lint

* Fix lint

* Fix

* Remove unnecessary file. (#108)

* Add Election (#109)

* elect

* Fix

* Fix

* Fix

* Fix lint

* Fix lint

* Fix election timer timeout.  (#110)

* Use constants instead of hard coding. (#111)

* Use constants instead of hard coding.

* Fix lint

* Add file class and test (#116)

* add file class and test

* modify code format

* code format

* modify format

* modify

* modify format

* add spdlog

add spdlog

add spdlog

* merge

* add spdlog

* add spdlog

* add spdlog

* add spdlog suport ci on win

* add spdlog

* clang-format

* add prefix for enum level

* code format

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add termid

* merge

* add nodeid

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand(),clang format

* add elect leader process

* add elect leader process

* add elect leader process

* Add elect leader process

Co-authored-by: TianYi <tianyime@qq.com>
Co-authored-by: 20083017 <liuquan2234@163.com>
Co-authored-by: 20083017 <651756340@qq.com>
Co-authored-by: Qing Wang <kingchin1218@gmail.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>
Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: wxing <wxing2008666@126.com>
Co-authored-by: wangxing4 <wangxing4@100tal.com>
Co-authored-by: leap <1546711908@qq.com>
Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>