### PR TITLE
Add election test. (#127)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ else()
 	set(link_libs )
 endif()
 
+if(WIN32)
+	ADD_DEFINITIONS(-DWIN32_LEAN_AND_MEAN)
+endif()
+
 RAFTCPP_DEFINE_TEST(example_counter_server_main SRC_FILES examples/counter/counter_server_main.cc LINKS node_lib gflags)
 RAFTCPP_DEFINE_TEST(test_timer SRC_FILES tests/timer_test.cc LINKS common_lib)
 RAFTCPP_DEFINE_TEST(test_range SRC_FILES tests/range_test.cc LINKS common_lib)
@@ -62,3 +66,4 @@ RAFTCPP_DEFINE_TEST(test_logging SRC_FILES tests/logging_test.cc LINKS common_li
 RAFTCPP_DEFINE_TEST(test_file SRC_FILES tests/file_test.cc LINKS common_lib)
 RAFTCPP_DEFINE_TEST(test_log_manager SRC_FILES tests/log_manager_test.cc LINKS common_lib)
 RAFTCPP_DEFINE_TEST(test_nodeid SRC_FILES tests/nodeid_test.cc LINKS common_lib)
+RAFTCPP_DEFINE_TEST(test_node_elect SRC_FILES tests/node_elect_test.cc LINKS common_lib node_lib)

--- a/cmake/Modules/Rest_rpcExternalProject.cmake
+++ b/cmake/Modules/Rest_rpcExternalProject.cmake
@@ -6,13 +6,13 @@
 #  - REST_RPC_INCLUDE_DIR
 #  - MSGPACK_INCLUDE_DIR
 
-set(REST_RPC_VERSION "0.06")
+set(REST_RPC_VERSION "0.09")
 
 set(REST_RPC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/external/rest-rpc-install")
 set(REST_RPC_INCLUDE_DIR "${REST_RPC_PREFIX}/include")
 set(MSGPACK_INCLUDE_DIR "${REST_RPC_PREFIX}/third/msgpack/include")
 
-set(REST_RPC_URL_MD5 "0d372e2bb3e30d103680732589930e4e")
+set(REST_RPC_URL_MD5 "eb4f76b2f4fbba05c305369cc6f965e9")
 
 ExternalProject_Add(rest_rpc_ep
         PREFIX external/rest-rpc

--- a/examples/counter/counter_server_main.cc
+++ b/examples/counter/counter_server_main.cc
@@ -5,7 +5,7 @@
 #include "common/config.h"
 #include "counter_state_machine.h"
 #include "node/node.h"
-#include "rpc_server.h"
+#include "rest_rpc/rpc_server.h"
 
 using namespace rest_rpc;
 using namespace rpc_service;

--- a/examples/counter/counter_service_def.h
+++ b/examples/counter/counter_service_def.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "common/status.h"
+#include "rest_rpc/rpc_server.h"
 #include "rpc/common.h"
-#include "rpc_server.h"
 
 using namespace rest_rpc;
 using namespace rpc_service;

--- a/src/node/node.h
+++ b/src/node/node.h
@@ -8,20 +8,23 @@
 #include "common/config.h"
 #include "common/endpoint.h"
 #include "common/id.h"
+#include "common/logging.h"
 #include "common/timer.h"
 #include "common/type_def.h"
 #include "node/timer_manager.h"
+#include "rest_rpc/rpc_client.hpp"
+#include "rest_rpc/rpc_server.h"
 #include "rpc/common.h"
 #include "rpc/services.h"
-#include "rpc_client.hpp"
-#include "rpc_server.h"
 
 namespace raftcpp {
 namespace node {
 
 class RaftNode : public rpc::NodeService {
 public:
-    RaftNode(rest_rpc::rpc_service::rpc_server &rpc_server, const common::Config &config);
+    RaftNode(
+        rest_rpc::rpc_service::rpc_server &rpc_server, const common::Config &config,
+        const raftcpp::RaftcppLogLevel severity = raftcpp::RaftcppLogLevel::RLL_DEBUG);
 
     ~RaftNode();
 
@@ -44,6 +47,10 @@ public:
     void OnRequestHeartbeat(rpc::RpcConn conn, int32_t term_id) override;
 
     void RequestHeartbeat();
+
+    void OnHeartbeat(const boost::system::error_code &ec, string_view data);
+
+    RaftState GetCurrState() const { return curr_state_; }
 
 private:
     void ConnectToOtherNodes();
@@ -81,6 +88,10 @@ private:
 
     // The recursive mutex that protects all of the node state.
     std::recursive_mutex mutex_;
+
+    // Accept the heartbeat reset election time to be random,
+    // otherwise the all followers will be timed out at one time.
+    Randomer randomer_;
 };
 
 }  // namespace node

--- a/src/rpc/services.h
+++ b/src/rpc/services.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <rpc_server.h>
+#include "rest_rpc/rpc_server.h"
 
 namespace raftcpp {
 namespace rpc {

--- a/tests/node_elect_test.cc
+++ b/tests/node_elect_test.cc
@@ -1,0 +1,211 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include <doctest.h>
+
+#include <thread>
+
+#include "../examples/counter/counter_service_def.h"
+#include "../examples/counter/counter_state_machine.h"
+#include "common/config.h"
+#include "common/logging.h"
+#include "node/node.h"
+#include "rest_rpc/rpc_server.h"
+
+class CounterServiceImpl {
+public:
+    // TODO(qwang): Are node and fsm uncopyable?
+    CounterServiceImpl(std::shared_ptr<raftcpp::node::RaftNode> node,
+                       std::shared_ptr<examples::counter::CounterStateMachine> &fsm)
+        : node_(std::move(node)), fsm_(std::move(fsm)) {}
+
+    void Incr(rpc_conn conn, int delta) {
+        examples::counter::IncrRequest request = examples::counter::IncrRequest(delta);
+        node_->Apply(request);
+    }
+
+    int64_t Get(rpc_conn conn) {
+        // There is no need to gurantee the write-read consistency,
+        // so we can get the value directly from this fsm instead of
+        // apply it to all nodes.
+        return fsm_->GetValue();
+    }
+
+private:
+    std::shared_ptr<raftcpp::node::RaftNode> node_;
+    std::shared_ptr<examples::counter::CounterStateMachine> fsm_;
+};
+
+void node_run(std::shared_ptr<raftcpp::node::RaftNode> &node, const std::string &conf_str,
+              rpc_server *server) {
+    const auto config = raftcpp::common::Config::From(conf_str);
+
+    node = std::make_shared<raftcpp::node::RaftNode>((*server), config,
+                                                     raftcpp::RaftcppLogLevel::RLL_DEBUG);
+    auto fsm = std::make_shared<examples::counter::CounterStateMachine>();
+
+    CounterServiceImpl service(node, fsm);
+    server->register_handler("incr", &CounterServiceImpl::Incr, &service);
+    server->register_handler("get", &CounterServiceImpl::Get, &service);
+    server->run();
+
+    return;
+}
+
+TEST_CASE("TestNodeElect") {
+    int LeaderFlag = 0;
+    std::vector<raftcpp::RaftState> nodeStateLeader;
+    std::vector<raftcpp::RaftState> nodeStateFollower;
+
+    std::shared_ptr<raftcpp::node::RaftNode> node1 = nullptr;
+    std::shared_ptr<raftcpp::node::RaftNode> node2 = nullptr;
+    std::shared_ptr<raftcpp::node::RaftNode> node3 = nullptr;
+
+    rpc_server *server1 = new rpc_server(10001, std::thread::hardware_concurrency());
+    rpc_server *server2 = new rpc_server(10002, std::thread::hardware_concurrency());
+    rpc_server *server3 = new rpc_server(10003, std::thread::hardware_concurrency());
+
+    std::thread t1(node_run, std::ref(node1),
+                   "127.0.0.1:10001,127.0.0.1:10002,127.0.0.1:10003", std::ref(server1));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    std::thread t2(node_run, std::ref(node2),
+                   "127.0.0.1:10002,127.0.0.1:10001,127.0.0.1:10003", std::ref(server2));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    std::thread t3(node_run, std::ref(node3),
+                   "127.0.0.1:10003,127.0.0.1:10001,127.0.0.1:10002", std::ref(server3));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    while (true) {
+        if (node1 && node2 && node3) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+
+    nodeStateFollower.clear();
+    nodeStateLeader.clear();
+    if (node1->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+        nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+    else if (node1->GetCurrState() == raftcpp::RaftState::LEADER) {
+        LeaderFlag = 1;
+        nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+    }
+
+    if (node2->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+        nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+    else if (node2->GetCurrState() == raftcpp::RaftState::LEADER) {
+        LeaderFlag = 2;
+        nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+    }
+
+    if (node3->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+        nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+    else if (node3->GetCurrState() == raftcpp::RaftState::LEADER) {
+        LeaderFlag = 3;
+        nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+    }
+
+    REQUIRE_EQ(nodeStateLeader.size(), 1);
+    REQUIRE_EQ(nodeStateFollower.size(), 2);
+
+    nodeStateFollower.clear();
+    nodeStateLeader.clear();
+    if (LeaderFlag == 1) {
+        delete server1;
+        server1 = nullptr;
+        node1.reset();
+        if (t1.joinable()) {
+            t1.detach();
+            t1.std::thread::~thread();
+        }
+    } else if (LeaderFlag == 2) {
+        delete server2;
+        server2 = nullptr;
+        node2.reset();
+        if (t2.joinable()) {
+            t2.detach();
+            t2.std::thread::~thread();
+        }
+    } else if (LeaderFlag == 3) {
+        delete server3;
+        server3 = nullptr;
+        node3.reset();
+        if (t3.joinable()) {
+            t3.detach();
+            t3.std::thread::~thread();
+        }
+    }
+
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    if (LeaderFlag == 1) {
+        if (node2->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node2->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+
+        if (node3->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node3->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+    } else if (LeaderFlag == 2) {
+        if (node1->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node1->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+
+        if (node3->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node3->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+    } else if (LeaderFlag == 3) {
+        if (node1->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node1->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+
+        if (node2->GetCurrState() == raftcpp::RaftState::FOLLOWER)
+            nodeStateFollower.push_back(raftcpp::RaftState::FOLLOWER);
+        else if (node2->GetCurrState() == raftcpp::RaftState::LEADER) {
+            nodeStateLeader.push_back(raftcpp::RaftState::LEADER);
+        }
+    }
+
+    REQUIRE_EQ(nodeStateLeader.size(), 1);
+    REQUIRE_EQ(nodeStateFollower.size(), 1);
+
+    if (server1) {
+        delete server1;
+        server1 = nullptr;
+        node1.reset();
+    }
+    if (server2) {
+        delete server2;
+        server2 = nullptr;
+        node2.reset();
+    }
+    if (server3) {
+        delete server3;
+        server3 = nullptr;
+        node3.reset();
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (t1.joinable()) {
+        t1.detach();
+        t1.std::thread::~thread();
+    }
+    if (t2.joinable()) {
+        t2.detach();
+        t2.std::thread::~thread();
+    }
+    if (t3.joinable()) {
+        t3.detach();
+        t3.std::thread::~thread();
+    }
+}


### PR DESCRIPTION
* 。

* add CI to support macos&ubuntu

* Add RaftNode (#39)

* Update Rest_rpcExternalProject.cmake

* add RaftNode
TODO:
use gflags to parse argv;
optimize raft node ut;

* Refine logger (#38)

* add LOG_DEBUG

* asio rest_rpc cmake

* Delete nanolog.hpp

* rest_rpc asio cmake

* addlogdebug

* addlogdebug

* addlogdebug

* addlogdebug

* release mode donn't output LogLevel::DEBUG

* add check_islogged function

* refine function name

Co-authored-by: 20083017 <651756340@qq.com>

* Refine structure (#41)

* Refine node.(#42)

* Add a simple tool `flags` for parse command line. (#43)

* Add flags

* flag

* Add more test for flags

* Hot fix CI.(#45)

* Refine run_all_tests for ci (#48)

* Add gflags. (#49)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>

* Enable code style check in CI. (#76)

* add clang-format check

* add set -x to shell scripts

* modify git-clang-format

* modify git-clang-format sh

* dev test

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* git-clang-format test

Co-authored-by: wangxing4 <wangxing4@100tal.com>

* git clang format (#78)

* git clang format

* delete useless code

* more jobs

* Run cpp lint on ubuntu only. (#80)

* Refine Counter example (#79)

* WIP

* WIP

* Fix

* FIx

* Fix compling

* Lint

* Fix lint

* Fix lint

* Minor refines (#81)

* FIX

* Fix

* Fix

* Fix lint

* Fix on windows

* Refine node (#82)

* Fix

* fix

* Fix

* Fix

* Fix lint

* Remove unnecessary test.

* Fix

* Fix

* Add log manager interface (#84)

* log

* Fix lint

* Implement Config class (#85)

* Add a random timer encapsulation for boost::timer. (#86)

* Add a timer.

* Add timer test.

* Fix lint

* Fix

* Fix lint

* FIx

* Fix test in macos

* Fix

* Fix config (#87)

* Add TimerManager (#88)

* Add cc library (#89)

* DONE

* Fix

* Fix lint

* Add cmake function to simplify test (#97)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

* add cmake function for test

Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>

* Add rpc server and rpc clients for node. (#98)

* WIP

* Fix

* Fix

* FIx

* Add remote call for node.  (#102)

* Clean code (#103)

* clean code.

* Fix

* Reset timer (#104)

* WIP

* Fix

* Fix

* Fix

* Fix lint

* Add ContinuousTimer. (#105)

* add ContinuousTimer

* Update timer.h of ContinuousTimer

* Update test_time.cc of ContinuousTimer

* Update timer.h of ContinuousTimer

Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>

* Add heartbeat rpc. (#106)

* Fix

* Fix

* Fix lint

* Add a mock logging. (#107)

* Fix lint

* Fix lint

* Fix

* Remove unnecessary file. (#108)

* Add Election (#109)

* elect

* Fix

* Fix

* Fix

* Fix lint

* Fix lint

* Fix election timer timeout.  (#110)

* Use constants instead of hard coding. (#111)

* Use constants instead of hard coding.

* Fix lint

* Add file class and test (#116)

* add file class and test

* modify code format

* code format

* modify format

* modify

* modify format

* add spdlog

add spdlog

add spdlog

* merge

* add spdlog

* add spdlog

* add spdlog

* add spdlog suport ci on win

* add spdlog

* clang-format

* add prefix for enum level

* code format

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add termid

* merge

* add nodeid

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand(),clang format

* add elect leader process

* add elect leader process

* add elect leader process

* Add elect leader process

* Add elect leader test

* Add elect leader test(code format)

* add WIN32_LEAN_AND_MEAN

* add line feed

* add elect leader test case

* add elect leader test case

* add elect leader test case

Co-authored-by: TianYi <tianyime@qq.com>
Co-authored-by: 20083017 <liuquan2234@163.com>
Co-authored-by: 20083017 <651756340@qq.com>
Co-authored-by: Qing Wang <kingchin1218@gmail.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>
Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: wxing <wxing2008666@126.com>
Co-authored-by: wangxing4 <wangxing4@100tal.com>
Co-authored-by: leap <1546711908@qq.com>
Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>