### PR TITLE
Use constants instead of magic number. (#129)

### DIFF
--- a/src/node/node.cc
+++ b/src/node/node.cc
@@ -65,8 +65,9 @@ void RaftNode::OnRequestPreVote(rpc::RpcConn conn, const std::string &endpoint_s
     if (curr_state_ == RaftState::FOLLOWER) {
         if (term_id > curr_term_id_.getTerm()) {
             curr_term_id_.setTerm(term_id);
-            timer_manager_.GetElectionTimerRef().Reset(2000 +
-                                                       randomer_.TakeOne(1000, 2000));
+            timer_manager_.GetElectionTimerRef().Reset(
+                RaftcppConstants::DEFAULT_HEARTBEAT_INTERVAL_MS +
+                randomer_.TakeOne(1000, 2000));
             if (conn_sp) {
                 conn_sp->response(req_id, config_.GetThisEndpoint().ToString());
             }
@@ -216,7 +217,9 @@ void RaftNode::OnRequestHeartbeat(rpc::RpcConn conn, int32_t term_id) {
                                << "received a heartbeat from leader."
                                << " curr_term_id_:" << curr_term_id_.getTerm()
                                << " receive term_id:" << term_id << " update term_id";
-        timer_manager_.GetElectionTimerRef().Start(2000 + randomer_.TakeOne(1000, 2000));
+        timer_manager_.GetElectionTimerRef().Start(
+            RaftcppConstants::DEFAULT_HEARTBEAT_INTERVAL_MS +
+            randomer_.TakeOne(1000, 2000));
         curr_term_id_.setTerm(term_id);
     } else {
         if (term_id >= curr_term_id_.getTerm()) {
@@ -229,8 +232,9 @@ void RaftNode::OnRequestHeartbeat(rpc::RpcConn conn, int32_t term_id) {
             timer_manager_.GetVoteTimerRef().Stop();
             timer_manager_.GetHeartbeatTimerRef().Stop();
             curr_state_ = RaftState::FOLLOWER;
-            timer_manager_.GetElectionTimerRef().Start(2000 +
-                                                       randomer_.TakeOne(1000, 2000));
+            timer_manager_.GetElectionTimerRef().Start(
+                RaftcppConstants::DEFAULT_HEARTBEAT_INTERVAL_MS +
+                randomer_.TakeOne(1000, 2000));
         } else {
             RAFTCPP_LOG(RLL_DEBUG)
                 << "OnRequestHeartbeat node "
@@ -256,7 +260,9 @@ void RaftNode::OnHeartbeat(const boost::system::error_code &ec, string_view data
     if (term_id > curr_term_id_.getTerm()) {
         curr_state_ = RaftState::FOLLOWER;
         timer_manager_.GetVoteTimerRef().Stop();
-        timer_manager_.GetElectionTimerRef().Start(2000 + randomer_.TakeOne(1000, 2000));
+        timer_manager_.GetElectionTimerRef().Start(
+            RaftcppConstants::DEFAULT_HEARTBEAT_INTERVAL_MS +
+            randomer_.TakeOne(1000, 2000));
         timer_manager_.GetHeartbeatTimerRef().Stop();
     }
 }


### PR DESCRIPTION
* 。

* add CI to support macos&ubuntu

* Add RaftNode (#39)

* Update Rest_rpcExternalProject.cmake

* add RaftNode
TODO:
use gflags to parse argv;
optimize raft node ut;

* Refine logger (#38)

* add LOG_DEBUG

* asio rest_rpc cmake

* Delete nanolog.hpp

* rest_rpc asio cmake

* addlogdebug

* addlogdebug

* addlogdebug

* addlogdebug

* release mode donn't output LogLevel::DEBUG

* add check_islogged function

* refine function name

Co-authored-by: 20083017 <651756340@qq.com>

* Refine structure (#41)

* Refine node.(#42)

* Add a simple tool `flags` for parse command line. (#43)

* Add flags

* flag

* Add more test for flags

* Hot fix CI.(#45)

* Refine run_all_tests for ci (#48)

* Add gflags. (#49)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>

* Enable code style check in CI. (#76)

* add clang-format check

* add set -x to shell scripts

* modify git-clang-format

* modify git-clang-format sh

* dev test

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* Update check-git-clang-format-output.sh

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* dev test

* git-clang-format test

Co-authored-by: wangxing4 <wangxing4@100tal.com>

* git clang format (#78)

* git clang format

* delete useless code

* more jobs

* Run cpp lint on ubuntu only. (#80)

* Refine Counter example (#79)

* WIP

* WIP

* Fix

* FIx

* Fix compling

* Lint

* Fix lint

* Fix lint

* Minor refines (#81)

* FIX

* Fix

* Fix

* Fix lint

* Fix on windows

* Refine node (#82)

* Fix

* fix

* Fix

* Fix

* Fix lint

* Remove unnecessary test.

* Fix

* Fix

* Add log manager interface (#84)

* log

* Fix lint

* Implement Config class (#85)

* Add a random timer encapsulation for boost::timer. (#86)

* Add a timer.

* Add timer test.

* Fix lint

* Fix

* Fix lint

* FIx

* Fix test in macos

* Fix

* Fix config (#87)

* Add TimerManager (#88)

* Add cc library (#89)

* DONE

* Fix

* Fix lint

* Add cmake function to simplify test (#97)

* compile pass in windows

* if build dir exist, remove it

* add windows ci

* modify ci step name

change "cmake" to "build" for uniform

* Merge remote-tracking branch 'upstream/master'

# Conflicts:
#	.github/workflows/c-cpp.yml

* add gflags， Windows pass

* add newline in the file end

* 1. remove the original flags implement.
2. enable gflags in the node_main.cc

* update ci

* 1. remove gflags test
2. remove show usage

* add cmake function for test

Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>

* Add rpc server and rpc clients for node. (#98)

* WIP

* Fix

* Fix

* FIx

* Add remote call for node.  (#102)

* Clean code (#103)

* clean code.

* Fix

* Reset timer (#104)

* WIP

* Fix

* Fix

* Fix

* Fix lint

* Add ContinuousTimer. (#105)

* add ContinuousTimer

* Update timer.h of ContinuousTimer

* Update test_time.cc of ContinuousTimer

* Update timer.h of ContinuousTimer

Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>

* Add heartbeat rpc. (#106)

* Fix

* Fix

* Fix lint

* Add a mock logging. (#107)

* Fix lint

* Fix lint

* Fix

* Remove unnecessary file. (#108)

* Add Election (#109)

* elect

* Fix

* Fix

* Fix

* Fix lint

* Fix lint

* Fix election timer timeout.  (#110)

* Use constants instead of hard coding. (#111)

* Use constants instead of hard coding.

* Fix lint

* Add file class and test (#116)

* add file class and test

* modify code format

* code format

* modify format

* modify

* modify format

* add spdlog

add spdlog

add spdlog

* merge

* add spdlog

* add spdlog

* add spdlog

* add spdlog suport ci on win

* add spdlog

* clang-format

* add prefix for enum level

* code format

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add nodeid

* add termid

* merge

* add nodeid

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand()

* use modern C++ random instead of rand(),clang format

* add elect leader process

* add elect leader process

* add elect leader process

* Add elect leader process

* Add elect leader test

* Add elect leader test(code format)

* add WIN32_LEAN_AND_MEAN

* add line feed

* add elect leader test case

* add elect leader test case

* add elect leader test case

* when reset timeout clock,use compile-time constants to instead of numbers literal

* Rollback

* when reset timeout,use compile-time constants to instead of numbers literal

Co-authored-by: TianYi <tianyime@qq.com>
Co-authored-by: 20083017 <liuquan2234@163.com>
Co-authored-by: 20083017 <651756340@qq.com>
Co-authored-by: Qing Wang <kingchin1218@gmail.com>
Co-authored-by: Praying <qurandeyouxiang@126.com>
Co-authored-by: Praying <snowfallvilla@163.com>
Co-authored-by: Praying <qurandeyouxiang@qq.com>
Co-authored-by: wxing <wxing2008666@126.com>
Co-authored-by: wangxing4 <wangxing4@100tal.com>
Co-authored-by: leap <1546711908@qq.com>
Co-authored-by: dxz <Dexin@zdxs-MacBook-Pro.local>